### PR TITLE
Update Visual Studio Code Workspace extension link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 ### Developer Tools
 
 - [Visual Studio](https://github.com/davidegiacometti/CmdPal-Extensions) - Search Visual Studio recents.
-- [Visual Studio Code](https://github.com/JonahFintzDev/CommandPaletteVSCode) - Open Visual Studio Code workspaces.
+- [Visual Studio Code](https://github.com/tanchekwei/VisualStudioCodeForCommandPalette) - Open Visual Studio Code/Visual Studio workspaces.
 
 ### Files 
 


### PR DESCRIPTION
Previous repo deprecated, updated link to reflect an alternate repo (as recommended in the README of the previous repo)